### PR TITLE
Encapsulate imports in the outline view in a container

### DIFF
--- a/de.gebit.integrity.dsl.ui/src/de/gebit/integrity/ui/outline/IntegrityDocumentRoot.java
+++ b/de.gebit.integrity.dsl.ui/src/de/gebit/integrity/ui/outline/IntegrityDocumentRoot.java
@@ -1,0 +1,39 @@
+package de.gebit.integrity.ui.outline;
+
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.xtext.ui.editor.model.IXtextDocument;
+import org.eclipse.xtext.ui.editor.outline.IOutlineNode;
+import org.eclipse.xtext.ui.editor.outline.impl.DocumentRootNode;
+
+/**
+ * Basic integrity root document.
+ * Extends the root node with a import container, which encapsulates all imports.
+ * 
+ * @author tilois
+ */
+public class IntegrityDocumentRoot extends DocumentRootNode {
+	/** Import container node. */
+	private IOutlineNode importContainer;
+	
+	public IntegrityDocumentRoot(Image image, Object text, IXtextDocument document,
+			DSLOutlineTreeProvider treeProvider) {
+		super(image, text, document, treeProvider);
+	}
+	
+	@Override
+	public DSLOutlineTreeProvider getTreeProvider() {
+		return (DSLOutlineTreeProvider) super.getTreeProvider();
+	}
+	
+	/**
+	 * Returns the import container, might delegate to the tree provider if not already computed.
+	 * @return Import container.
+	 */
+	public IOutlineNode getImportContainer() {
+		if (importContainer == null) {
+			importContainer = getTreeProvider().createOutlineContainer(this);
+		}
+		return importContainer;
+	}
+	
+}

--- a/de.gebit.integrity.dsl.ui/src/de/gebit/integrity/ui/outline/OutlineImportContainer.java
+++ b/de.gebit.integrity.dsl.ui/src/de/gebit/integrity/ui/outline/OutlineImportContainer.java
@@ -1,0 +1,18 @@
+package de.gebit.integrity.ui.outline;
+
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.xtext.ui.editor.outline.IOutlineNode;
+import org.eclipse.xtext.ui.editor.outline.impl.AbstractOutlineNode;
+
+/**
+ * Basic outline node which encapsulates the imports. 
+ * @author tilois
+ */
+// As there is no generic (non-abstract) outline node, we need to create specialized ones.
+public class OutlineImportContainer extends AbstractOutlineNode {
+
+	protected OutlineImportContainer(IOutlineNode parent, Image image, Object text, boolean isLeaf) {
+		super(parent, image, text, isLeaf);
+	}
+
+}


### PR DESCRIPTION
Encapsulates imports in the outline in a synthetic container element.

This enables one to fold this container (which is the default). A long list of imports will therefor not bloat the outline.

Also fixes a missing null check for the import name, which should prevent an NPE when writing an import, where there is no valid text anywhere after the import keyword.
