### PR TITLE
Make overriding build-in XSLT possible

### DIFF
--- a/de.gebit.integrity.runner/src/de/gebit/integrity/runner/callbacks/xml/XmlWriterTestCallback.java
+++ b/de.gebit.integrity.runner/src/de/gebit/integrity/runner/callbacks/xml/XmlWriterTestCallback.java
@@ -521,7 +521,7 @@ public class XmlWriterTestCallback extends AbstractTestRunnerCallback {
 	 * 
 	 * @return the xslt stream
 	 */
-	private InputStream getXsltStream() {
+	protected InputStream getXsltStream() {
 		return getClass().getClassLoader().getResourceAsStream("resource/xhtml.xslt");
 	}
 


### PR DESCRIPTION
For different environments, a specific html rendering may be necessary or
desirable. If getXsltStream is private, an error-prone caller search and
replace is required. Therefore, it is preferrable to make the method
overridable directly.
